### PR TITLE
Introduce ADRs and initial template

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,30 +1,6 @@
 Installation
 ============
 
-
-
-Homebrew (MacOS X)
-------------------
-
-Mac OS X users can install with [Homebrew](https://brew.sh):
-
-    brew install adr-tools
-
-ASDF-VM (Linux, MacOS X)
-------------------------
-
-ADR-Tools can be installed from the [ASDF-VM version manager](https://github.com/asdf-vm/asdf).
-
-From a Release Package (Linux, MacOS X)
----------------------------------------
-
-You can install a released package:
-
-1. Download a zip or tar.gz package from the [releases page](https://github.com/npryce/adr-tools/releases)
-2. Unzip / untar the package
-3. Add the 'src/' subdirectory to your PATH
-
-
 From Git (Linux, MacOS X)
 -------------------------
 
@@ -32,24 +8,6 @@ You can install with Git, if you want to be on the bleeding edge:
 
 1. Clone this repository
 2. Add the `src/` subdirectory to your PATH.
-
-
-Windows 10
-----------
-
-### Git for Windows: git bash
-
-When using git bash within [Git for Windows](https://git-for-windows.github.io/), the scripts can simply be put in `usr\bin` in the installation directory.  That directory usually is `C:\Program Files\Git\usr\bin`.
-
-1. Download a zip package from the [releases page](https://github.com/npryce/adr-tools/releases)
-2. Unzip the package
-3. Copy everything from `src/` into `C:\Program Files\Git\usr\bin`
-4. Pottery expects to run in a standard POSIX environment, so you must also install `more` or set the `PAGER` environment variable to `less`.
-
-### Linux subsystem
-
-The scripts work in the Bash on [Ubuntu on Windows](https://www.microsoft.com/store/p/ubuntu/9nblggh4msv6), the Linux-subsystem that officially supports Linux command line tools.
-Make sure that you have [installed](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) the Linux-subsystem, run `bash` on the command line and follow the instructions in the "From a Release Package" section above.
 
 Autocomplete
 ----------

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ ADR Tools
 
 A command-line tool for working with a log of [Architecture Decision Records][ADRs] (ADRs).
 
-[![Build Status](https://travis-ci.org/npryce/adr-tools.svg?branch=master)](https://travis-ci.org/npryce/adr-tools)
-
 Quick Start
 -----------
 

--- a/src/template.md
+++ b/src/template.md
@@ -1,7 +1,7 @@
 # [short title of solved problem and solution]
 
 * Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
-* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Directly Responsible Individual (DRI): [Name the person that owns this decision)
 * Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
 
 Technical Story: [description | ticket/issue URL] <!-- optional -->


### PR DESCRIPTION
Following up on our discussion of ADRs yesterday, I've added this repo to our Github org. I found this tooling to be useful in generating consistently structured ADRs.

**Using this tool is optional.**

- Modifies "Deciders" to be "DRI" in the template.
- Truncates the installation options.
  - We've forked this repo from upstream and don't currently have any
build/release procedures set up for this.
    - For the time being, cloning this repo and adding it to one's PATH
  will get us up and running, if folks want to use this tool.
- Removes a CI badge that no longer applies.